### PR TITLE
[#19] Add a profile to run lint and test:travis-headless from maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -457,6 +457,48 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>Test the UI</id>
+            <activation>
+                <property>
+                    <name>ob.ui.tests</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.github.eirslett</groupId>
+                        <artifactId>frontend-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <!--
+                                    Run the linter
+                                -->
+                                <id>yarn run lint</id>
+                                <goals>
+                                    <goal>yarn</goal>
+                                </goals>
+                                <configuration>
+                                    <arguments>run lint</arguments>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <!--
+                                    Run the tests
+                                -->
+                                <id>yarn run test:travis-headless</id>
+                                <goals>
+                                    <goal>yarn</goal>
+                                </goals>
+                                <configuration>
+                                    <arguments>run test:travis-headless</arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
     <!-- After upgrading IntelliJ IDEA to 2016.3.2, this is suddenly needed -->


### PR DESCRIPTION
My hope is that this will be preparation to move the whole travis build to be
java based, which will allow us to also run the java unit tests on
travis and one day have some integration tests against a running jira
instance.