### PR TITLE
Don't set UserSettingState.currentVisibleColumns

### DIFF
--- a/webapp/src/app/app.module.ts
+++ b/webapp/src/app/app.module.ts
@@ -115,7 +115,7 @@ export function getInitialAppState(): AppState {
     ReactiveFormsModule,
     AppRoutingModule,
     StoreModule.forRoot(reducers, {initialState: getInitialAppState, metaReducers: metaReducers}),
-    !environment.production ? StoreDevtoolsModule.instrument({ maxAge: 2 }) : []
+    !environment.production ? StoreDevtoolsModule.instrument({ maxAge: 10 }) : []
   ],
   providers: [
     {provide: APP_BASE_HREF, useValue: '/'},

--- a/webapp/src/app/components/board/board.component.ts
+++ b/webapp/src/app/components/board/board.component.ts
@@ -22,6 +22,7 @@ import {filter, take, takeUntil} from 'rxjs/operators';
 import {IssueState} from '../../model/board/data/issue/issue.model';
 import {issueStateSelector} from '../../model/board/data/issue/issue.reducer';
 import {ToolbarTitleService} from '../../services/toolbar-title.service';
+import {backlogStatesSelector} from '../../model/board/data/header/header.reducer';
 
 
 @Component({
@@ -132,6 +133,13 @@ export class BoardComponent implements OnInit, OnDestroy {
           }
           this.blacklist = blacklist;
         });
+
+    this._store.select(backlogStatesSelector)
+      .pipe(take(1))
+      .subscribe(backlogStates => {
+        // The user settings need to know  the number of backlog states
+        this._store.dispatch(UserSettingActions.createSetBacklogStates(backlogStates));
+      });
   }
 
   ngOnDestroy(): void {

--- a/webapp/src/app/components/board/view/board-view-headers/board-header-group.component.ts
+++ b/webapp/src/app/components/board/view/board-view-headers/board-header-group.component.ts
@@ -44,7 +44,7 @@ export class BoardHeaderGroupComponent implements OnInit {
   }
 
   onToggleVisibility(header: BoardHeader) {
-    if (!header.backlog || this.viewMode === this.enumViewMode.RANK) {
+    if (!header.backlog) {
       this.toggleColumnVisibility.next(header);
     } else {
       if (header.category) {

--- a/webapp/src/app/model/board/data/header/header.reducer.ts
+++ b/webapp/src/app/model/board/data/header/header.reducer.ts
@@ -1,7 +1,9 @@
 import {List, Map} from 'immutable';
 import {HeaderUtil, initialHeaderState} from './header.model';
-import {Action} from '@ngrx/store';
+import {Action, createSelector} from '@ngrx/store';
 import {HeaderState} from './header.state';
+import {AppState} from '../../../../app-store';
+import {CustomFieldState} from '../custom-field/custom-field.model';
 
 
 const DESERIALIZE_HEADERS = 'DESERIALIZE_HEADERS';
@@ -84,4 +86,9 @@ interface DeserializeHeadersPayload {
   backlog: number;
   done: number;
 }
+
+const getHeaderState = (state: AppState) => state.board.headers;
+const getBacklogStates = (state: HeaderState) => state.backlog;
+export const backlogStatesSelector = createSelector(getHeaderState, getBacklogStates);
+
 

--- a/webapp/src/app/model/board/user/user-setting.model.ts
+++ b/webapp/src/app/model/board/user/user-setting.model.ts
@@ -7,6 +7,7 @@ import {initialIssueDetailState} from './issue-detail/issue-detail.model';
 import {initialBoardSearchFilterState} from './board-filter/board-search-filter.model';
 
 const DEFAULT_STATE: UserSettingState = {
+  backlogStates: 0,
   boardCode: '',
   viewMode: BoardViewMode.KANBAN,
   forceBacklog: false,

--- a/webapp/src/app/model/board/user/user-setting.reducer.spec.ts
+++ b/webapp/src/app/model/board/user/user-setting.reducer.spec.ts
@@ -575,12 +575,10 @@ describe('User setting reducer tests', () => {
 
           state = userSettingReducer(state, UserSettingActions.createToggleBacklog(getBacklogHeaderForToggle()));
           checker.showBacklog = true;
-          checker.visibleColumns = {0: true};
           checker.check(state);
 
           state = userSettingReducer(state, UserSettingActions.createToggleBacklog(getBacklogHeaderForToggle()));
           checker.showBacklog = false;
-          checker.visibleColumns = {0: false};
           checker.check(state);
         });
       });
@@ -623,13 +621,12 @@ describe('User setting reducer tests', () => {
 
           state = userSettingReducer(state, UserSettingActions.createToggleBacklog(getBacklogHeaderForToggle()));
           checker.showBacklog = false;
-          checker.visibleColumns = {0: false};
+          checker.visibleColumns = {};
           checker.check(state);
 
           state = userSettingReducer(state, UserSettingActions.createToggleBacklog(getBacklogHeaderForToggle()));
           checker.showBacklog = true;
-          checker.visibleColumns = {0: true
-          };
+          checker.visibleColumns = {};
           checker.check(state);
         });
       });

--- a/webapp/src/app/model/board/user/user-setting.ts
+++ b/webapp/src/app/model/board/user/user-setting.ts
@@ -5,6 +5,7 @@ import {IssueDetailState} from './issue-detail/issue-detail.model';
 import {BoardSearchFilterState} from './board-filter/board-search-filter.model';
 
 export interface UserSettingState {
+  backlogStates: number;
   boardCode: string;
   viewMode: BoardViewMode;
   forceBacklog: boolean;

--- a/webapp/src/app/view-model/board/filter.util.ts
+++ b/webapp/src/app/view-model/board/filter.util.ts
@@ -131,6 +131,7 @@ export class AllFilters {
     if (!this._issueType.doFilter(issue.type.name)) {
       return false;
     }
+    console.log('----> ' + issue.key);
     if (!this._assignee.doFilter(issue.assignee !== NO_ASSIGNEE ? issue.assignee.key : null)) {
       return false;
     }

--- a/webapp/src/rest/overbaard/1.0/issues/POC2.json
+++ b/webapp/src/rest/overbaard/1.0/issues/POC2.json
@@ -122,7 +122,7 @@
       "components": [0, 1],
       "fix-versions": [0,1],
       "labels": [0, 1],
-      "assignee": 1,
+      "assignee": 0,
       "custom": {"User Custom Field": 0, "Version Custom Field": 1}
     },
     "FEAT-2" : {


### PR DESCRIPTION
if they are the same as the default.

Toggle backlog even in rank view mode,

Together thse solve:

1) Problem where if in Kanban view show and then hide the
backlog, you end up with the backlog states hidden in the Rank view.

2) If you show the backlog in the Kanban view and go to the rank
view, and there collapse the backlog header/hide all backlog states,
when you come back to the kanban view the backlog is correctly hidden.
To show the backlog again you need TWO clicks, which seems to indicate
that the backlog header is in a strange state

Follow-up on #109